### PR TITLE
Use hash-set instead of data literal

### DIFF
--- a/src/zuko/entity/reader.cljc
+++ b/src/zuko/entity/reader.cljc
@@ -96,7 +96,7 @@
      (persistent!
       (reduce (fn [m [k v]]
                 (assoc! m k (if-let [[km vm] (find m k)]
-                              (if (set? vm) (conj vm v) #{vm v})
+                              (if (set? vm) (conj vm v) (hash-set vm v))
                               v)))
               (transient {}) kvs))
      :cljs
@@ -104,7 +104,7 @@
       (reduce (fn [m [k v]]
                 (assoc! m k (let [vm (get m k ::null)]
                               (if-not (= ::null vm)
-                                (if (set? vm) (conj vm v) #{vm v})
+                                (if (set? vm) (conj vm v) (hash-set vm v))
                                 v))))
               (transient {}) kvs))))
 


### PR DESCRIPTION
This resolves `java.lang.IllegalArgumentException`s in the case that
vm and v are the same value.

    (let [vm :a, v :a]
      #{vm v})
    ;; =>
    ;; 1. Unhandled java.lang.IllegalArgumentException
    ;;    Duplicate key: :a