### PR TITLE
Restructure ns-publics map to reduce bundle impact

### DIFF
--- a/src/zuko/util.cljc
+++ b/src/zuko/util.cljc
@@ -6,12 +6,15 @@
 
 ;; NOTE: this code avoids cljs.js due to inconsistency in how it gets loaded in standard configurations
 
-#?(:cljs (def known-namespaces {'cljs.core (ns-publics 'cljs.core)
-                                'clojure.core (ns-publics 'cljs.core)
-                                'clojure.string (ns-publics 'clojure.string)
-                                "cljs.core" (ns-publics 'cljs.core)
-                                "clojure.core" (ns-publics 'cljs.core)
-                                "clojure.string" (ns-publics 'clojure.string)}))
+#?(:cljs (def ns-publics-map {'cljs.core (ns-publics 'cljs.core)
+                              'clojure.string (ns-publics 'clojure.string)}))
+
+#?(:cljs (def known-namespaces {'cljs.core (ns-publics-map 'cljs.core)
+                                'clojure.core (ns-publics-map 'cljs.core)
+                                'clojure.string (ns-publics-map 'clojure.string)
+                                "cljs.core" (ns-publics-map 'cljs.core)
+                                "clojure.core" (ns-publics-map 'cljs.core)
+                                "clojure.string" (ns-publics-map 'clojure.string)}))
 
 #?(:clj
    (s/defn get-fn-reference :- (s/maybe Var)


### PR DESCRIPTION
Only include`cljs.core` and `clojure.string` once instead of three times, a first simple way to address #9.

Shadow cljs build report using `:advanced` before:
<img width="823" alt="CleanShot 2021-03-09 at 17 03 24@2x" src="https://user-images.githubusercontent.com/1187/110503123-2cffaf00-80fc-11eb-8b9e-e2fcbfd9e538.png">

and after this change:
<img width="822" alt="CleanShot 2021-03-09 at 17 09 56@2x" src="https://user-images.githubusercontent.com/1187/110503232-456fc980-80fc-11eb-9dfc-9747c4cbb7cf.png">
